### PR TITLE
Libxc

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+ignore:
+  - "tests/"
+  - "psi4/driver/qcdb/"
+  - "psi4/share/"
+  - "psi4/src/psi4/libtrans/"
+  - "psi4/src/psi4/transqt2/"
+  - "psi4/src/psi4/lib3index/"
+  - "psi4/src/psi4/libfilesystem/"
+  - "psi4/src/psi4/libiwl/"
+  - "psi4/src/psi4/libthce/"
+  - "psi4/src/psi4/libfunctional/"

--- a/.gitignore
+++ b/.gitignore
@@ -48,13 +48,17 @@ input.py.dat
 *.clean
 *timer.dat
 *.molden
+*.intco
+*.dma
+*.fchk.dat
+input.py.dat
+
 
 # Special test cases
 tests/*/iter.dat
 tests/*/*.in
 tests/*/*.rst
 tests/*/*/*.h5
-tests/*/*/*.intco
 tests/docs*/*.txt
 tests/pcmsolver/*/*OUT*
 tests/pcmsolver/*/cavity*

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -139,7 +139,7 @@ std::vector<std::tuple<std::string, int, double>> LibXCFunctional::get_mix_data(
         std::string name = std::string(xc_functional_.info->name);
         int kind = xc_functional_.info->kind;
         double coef = 1.0;
-        ret.push_back({name, kind, coef});
+        ret.push_back(std::make_tuple(name, kind, coef));
 
     } else {
         for (size_t i = 0; i < xc_functional_.n_func_aux; i++) {
@@ -148,7 +148,7 @@ std::vector<std::tuple<std::string, int, double>> LibXCFunctional::get_mix_data(
             int kind = xc_functional_.func_aux[i]->info->kind;
             double coef = xc_functional_.mix_coef[i];
 
-            ret.push_back({name, kind, coef});
+            ret.push_back(std::make_tuple(name, kind, coef));
         }
     }
     return ret;


### PR DESCRIPTION
## Description
Fixes error I was having with compiling. Tuples were not being recognized in curly braces and required the std::make_tuple() function to compile.

## Status
- [X]  Ready to go


