### PR TITLE
Added new DFT functionals: B1B95, B5050LYP, BHHLYP, BOP, M11-L, MGGA_MS0, MGGA_MS1, and MGGA_MS2

### DIFF
--- a/psi4/driver/procedures/dft_funcs/gga_superfuncs.py
+++ b/psi4/driver/procedures/dft_funcs/gga_superfuncs.py
@@ -75,6 +75,28 @@ def build_blyp_superfunctional(name, npoints, deriv, restricted):
     sup.allocate()
     return (sup, False)
 
+def build_bop_superfunctional(name, npoints, deriv, restricted):
+
+    # Call this first
+    sup = core.SuperFunctional.blank()
+    sup.set_max_points(npoints)
+    sup.set_deriv(deriv)
+
+    # => User-Customization <= #
+
+    # No spaces, keep it short and according to convention
+    sup.set_name('BOP')
+    sup.set_description('    BOP GGA Exchange-Correlation Functional\n')
+    sup.set_citation('    T. Tsuneda et. al., J. Chem. Phys. 110, 10664-10678, 1999\n')
+
+    # Add member functionals
+    sup.add_x_functional(core.LibXCFunctional.build_base('XC_GGA_X_B88', restricted))
+    sup.add_c_functional(core.LibXCFunctional.build_base('XC_GGA_C_OP_B88', restricted))
+
+    # Call this last
+    sup.allocate()
+    return (sup, False)
+
 def build_b86bpbe_superfunctional(name, npoints, deriv, restricted):
 
     # Call this first
@@ -249,4 +271,5 @@ gga_superfunc_list = {
           "bp86"    : build_bp86_superfunctional,
           "pw91"    : build_pw91_superfunctional,
           "ft97"    : build_ft97_superfunctional,
+          "bop"     : build_bop_superfunctional,
 }

--- a/psi4/driver/procedures/dft_funcs/hyb_superfuncs.py
+++ b/psi4/driver/procedures/dft_funcs/hyb_superfuncs.py
@@ -59,6 +59,41 @@ def build_pbe0_superfunctional(name, npoints, deriv, restricted):
     sup.allocate()
     return (sup, False)
 
+def build_b5050lyp_superfunctional(name, npoints, deriv, restricted):
+    # Call this first
+    sup = core.SuperFunctional.blank()
+    sup.set_max_points(npoints)
+    sup.set_deriv(deriv)
+
+    # => User-Customization <= #
+
+    # No spaces, keep it short and according to convention
+    sup.set_name('B5050LYP')
+    # Tab in, trailing newlines
+    sup.set_description('    B5050LYP Hyb-GGA Exchange-Correlation Functional\n')
+    # Tab in, trailing newlines
+    sup.set_citation('    Y. Shao et. al., J. Chem. Phys., 188, 4807-4818, 2003\n')
+
+    # Add member functionals
+    slater = core.LibXCFunctional.build_base("XC_LDA_X", restricted)
+    slater.set_alpha(0.08)
+    sup.add_x_functional(slater)
+    becke = core.LibXCFunctional.build_base("XC_GGA_X_B88", restricted)
+    becke.set_alpha(0.42)
+    sup.add_x_functional(becke)
+    sup.set_x_alpha(0.50) 
+
+    vwn = core.LibXCFunctional.build_base("XC_LDA_C_VWN", restricted) 
+    vwn.set_alpha(0.19)
+    sup.add_c_functional(vwn)
+    lyp = core.LibXCFunctional.build_base("XC_GGA_C_LYP", restricted) 
+    lyp.set_alpha(0.81)
+    sup.add_c_functional(lyp)
+
+    # Call this last
+    sup.allocate()
+    return (sup, False)
+
 def build_wpbe_superfunctional(name, npoints, deriv, restricted):
 
     # Call this first
@@ -173,12 +208,13 @@ def build_hf_superfunctional(name, npoints, deriv, restricted):
 
 
 hyb_superfunc_list = {
-          "pbe0"    : build_pbe0_superfunctional,
-          "wpbe"    : build_wpbe_superfunctional,
-          "wpbe0"   : build_wpbe0_superfunctional,
-          "wb97x-d" : build_wb97xd_superfunctional,
-          "hf-d"    : build_hfd_superfunctional,
-          "hf"      : build_hf_superfunctional,
+          "pbe0"     : build_pbe0_superfunctional,
+          "wpbe"     : build_wpbe_superfunctional,
+          "wpbe0"    : build_wpbe0_superfunctional,
+          "b5050lyp" : build_b5050lyp_superfunctional,
+          "wb97x-d"  : build_wb97xd_superfunctional,
+          "hf-d"     : build_hfd_superfunctional,
+          "hf"       : build_hf_superfunctional,
 
 }
 

--- a/psi4/driver/procedures/dft_funcs/libxc_xc_funcs.py
+++ b/psi4/driver/procedures/dft_funcs/libxc_xc_funcs.py
@@ -167,6 +167,8 @@ for x in xc_func_list:
 # Add extra translations
 psi_to_xc_translate["b97-0"] = "XC_HYB_GGA_XC_B97"
 psi_to_xc_translate["hcth"] = "XC_GGA_XC_HCTH_93"
+psi_to_xc_translate["b1b95"] = "XC_HYB_MGGA_XC_B88B95"
+psi_to_xc_translate["bhhlyp"] = "XC_HYB_GGA_XC_BHANDHLYP"
 
 
 def find_xc_func_name(name):

--- a/psi4/driver/procedures/dft_funcs/mgga_superfuncs.py
+++ b/psi4/driver/procedures/dft_funcs/mgga_superfuncs.py
@@ -70,9 +70,102 @@ def build_dldfd10_superfunctional(name, npoints, deriv, restricted):
 
     return (sup, ('dlDF', '-DAS2010'))
 
+def build_m11_l_superfunctional(name, npoints, deriv, restricted):
+
+    # Call this first
+    sup = core.SuperFunctional.blank()
+    sup.set_max_points(npoints)
+    sup.set_deriv(deriv)
+
+    # => User-Customization <= #
+
+    # No spaces, keep it short and according to convention
+    sup.set_name('M11-L')
+    sup.set_description('    M11-L Meta-GGA XC Functional\n')
+    sup.set_citation('    R. Peverati and D. G. Truhlar, J. Phys. Chem. Lett. 3, 117-124, 2012\n')
+
+    # Add member functionals
+    sup.add_x_functional(core.LibXCFunctional.build_base('XC_MGGA_X_M11_L', restricted))
+    sup.add_c_functional(core.LibXCFunctional.build_base('XC_MGGA_C_M11_L', restricted))
+
+    # Call this last
+    sup.allocate()
+    return (sup, False)
+
+def build_mgga_ms0_superfunctional(name, npoints, deriv, restricted):
+
+    # Call this first
+    sup = core.SuperFunctional.blank()
+    sup.set_max_points(npoints)
+    sup.set_deriv(deriv)
+
+    # => User-Customization <= #
+
+    # No spaces, keep it short and according to convention
+    sup.set_name('MGGA_MS0')
+    sup.set_description('    MGGA_MS0 Meta-GGA XC Functional\n')
+    sup.set_citation('    J. Sun et. al., J. Chem. Phys. 137, 051101, 2012\n')
+
+    # Add member functionals
+    sup.add_x_functional(core.LibXCFunctional.build_base('XC_MGGA_X_MS0', restricted))
+    sup.add_c_functional(core.LibXCFunctional.build_base('XC_GGA_C_REGTPSS', restricted))
+
+    # Call this last
+    sup.allocate()
+    return (sup, False)
+
+
+def build_mgga_ms1_superfunctional(name, npoints, deriv, restricted):
+
+    # Call this first
+    sup = core.SuperFunctional.blank()
+    sup.set_max_points(npoints)
+    sup.set_deriv(deriv)
+
+    # => User-Customization <= #
+
+    # No spaces, keep it short and according to convention
+    sup.set_name('MGGA_MS1')
+    sup.set_description('    MGGA_MS1 Meta-GGA XC Functional\n')
+    sup.set_citation('    J. Sun et. al., J. Chem. Phys. 138, 044113, 2013\n')
+
+    # Add member functionals
+    sup.add_x_functional(core.LibXCFunctional.build_base('XC_MGGA_X_MS1', restricted))
+    sup.add_c_functional(core.LibXCFunctional.build_base('XC_GGA_C_REGTPSS', restricted))
+
+    # Call this last
+    sup.allocate()
+    return (sup, False)
+
+def build_mgga_ms2_superfunctional(name, npoints, deriv, restricted):
+
+    # Call this first
+    sup = core.SuperFunctional.blank()
+    sup.set_max_points(npoints)
+    sup.set_deriv(deriv)
+
+    # => User-Customization <= #
+
+    # No spaces, keep it short and according to convention
+    sup.set_name('MGGA_MS2')
+    sup.set_description('    MGGA_MS2 Meta-GGA XC Functional\n')
+    sup.set_citation('    J. Sun et. al., J. Chem. Phys. 138, 044113, 2013\n')
+
+    # Add member functionals
+    sup.add_x_functional(core.LibXCFunctional.build_base('XC_MGGA_X_MS2', restricted))
+    sup.add_c_functional(core.LibXCFunctional.build_base('XC_GGA_C_REGTPSS', restricted))
+
+    # Call this last
+    sup.allocate()
+    return (sup, False)
+
 
 mgga_superfunc_list = {
-          "dldf" : build_dldf_superfunctional,
+          "dldf"     : build_dldf_superfunctional,
           "dldf+d09" : build_dldfd09_superfunctional,
-          "dldf+d" : build_dldfd10_superfunctional,
+          "dldf+d"   : build_dldfd10_superfunctional,
+          "m11-l"    : build_m11_l_superfunctional,
+          "mgga_ms0" : build_mgga_ms0_superfunctional,
+          "mgga_ms1" : build_mgga_ms1_superfunctional,
+          "mgga_ms2" : build_mgga_ms2_superfunctional,
 }


### PR DESCRIPTION
```
           Functional:            libxc :      rob    qchem
Comparison      B1B95:   -76.3535238134 :      nan 7.49e-07 
Comparison      B1LYP:   -76.3535287675 :      nan 5.92e-06 
Comparison     B1PW91:   -76.3655283982 :      nan 7.85e-06 
Comparison     B2PLYP:   -76.2924549113 : 6.51e-10      nan 
Comparison      B3LYP:   -76.3850665212 : 3.77e-12 6.46e-06 
Comparison     B3LYP5:   -76.3479691966 : 3.85e-12 5.09e-06 
Comparison      B3P86:   -76.4015870529 :      nan 5.59e-05 
Comparison     B3PW91:   -76.3571043449 :      nan 4.99e-06 
Comparison   B5050LYP:   -76.3332164704 :      nan 2.41e-05 
Comparison    B86BPBE:   -76.3641617415 : 1.66e-05      nan *
Comparison        B97:   -76.3580621766 :      nan 1.88e-05 
Comparison      B97-0:   -76.3580621766 : 1.21e-12      nan 
Comparison      B97-1:   -76.3597138942 : 2.00e-12 1.72e-05 
Comparison      B97-2:   -76.3583977126 : 3.69e-13 1.72e-05 
Comparison      B97-3:   -76.3648962711 :      nan 3.63e-06 
Comparison      B97-D:   -76.3454256203 : 6.60e-05 5.52e-05 *
Comparison      B97-K:   -76.3525031958 :      nan 1.02e-05 
Comparison       BB1K:   -76.3467136774 :      nan 2.69e-06 
Comparison     BHHLYP:   -76.3412658216 :      nan 3.22e-05 
Comparison       BLYP:   -76.3664599377 : 7.63e-12 5.28e-06 
Comparison        BOP:   -76.3668888508 :      nan 8.34e-06 
Comparison       BP86:   -76.3865429463 : 1.48e-11 6.61e-05 
Comparison  CAM-B3LYP:   -76.9600066727 :      nan 6.05e-01 *
Comparison       DLDF:   -76.8410958136 : 7.01e-06 5.49e-06 *
Comparison     DLDF+D:   -76.8410958136 : 7.01e-06      nan *
Comparison   DLDF+D09:   -76.8410958136 : 7.01e-06      nan *
Comparison       EDF1:   -76.3977441624 :      nan 1.42e-05 
Comparison       EDF2:   -76.3447690880 :      nan 2.44e-05 
Comparison       FT97:   -76.3465055306 :      nan      nan 
Comparison       HCTH:   -76.3690845767 : 1.92e-12      nan 
Comparison    HCTH120:   -76.3758214261 : 5.54e-13 9.16e-06 
Comparison    HCTH147:   -76.3796912252 : 1.83e-12 6.49e-06 
Comparison    HCTH407:   -76.3749444113 : 4.16e-12 9.33e-06 
Comparison     HCTH93:   -76.3690845767 :      nan 8.26e-06 
Comparison   LRC-WPBE:   -76.3233380118 :      nan 4.21e-05 
Comparison  LRC-WPBEH:   -76.3099577053 :      nan 1.03e-05 
Comparison        M05:   -76.3485709027 : 5.35e-06 3.86e-06 *
Comparison     M05-2X:   -76.3677259246 : 2.04e-06 6.44e-06 *
Comparison        M06:   -76.3505176815 :      nan 8.11e-06 
Comparison     M06-2X:   -76.3484287966 :      nan 1.21e-06 
Comparison     M06-HF:   -76.3434595759 :      nan 1.14e-05 
Comparison     M08-HX:   -76.3491493906 :      nan 1.20e-05 
Comparison     M08-SO:   -76.3326311927 :      nan 3.68e-05 
Comparison        M11:   -76.3543917917 :      nan 1.46e-05 
Comparison      M11-L:   -76.3618330706 :      nan 1.11e-05 
Comparison   MGGA_MS0:   -76.3991061588 :      nan 1.14e-05 
Comparison   MGGA_MS1:   -76.3862788654 :      nan 1.14e-05 
Comparison   MGGA_MS2:   -76.3945060031 :      nan 9.56e-05 
Comparison    MPW1B95:   -76.3499774194 :      nan 8.57e-09 
Comparison      MPW1K:   -76.3552196049 :      nan 7.38e-06 
Comparison     MPWB1K:   -76.3440591060 :      nan 3.17e-06 
Comparison      O3LYP:   -76.3591578176 :      nan 8.61e-06 
Comparison        PBE:   -76.2994541311 : 6.85e-12 5.69e-06 
Comparison       PBE0:   -76.3005012836 : 3.89e-12 3.19e-07 
Comparison     PBE0-2:   -76.2133253426 : 7.66e-09      nan 
Comparison     PW6B95:   -76.4628549510 :      nan 8.28e-07 
Comparison    PW86PBE:   -76.4209577137 : 3.85e-12      nan 
Comparison       PW91:   -76.3565672872 : 1.48e-12 1.23e-04 *
Comparison      PWB6K:   -76.4078425155 :      nan 3.61e-06 
Comparison   REVTPSSH:   -76.3534641855 :      nan 4.93e-06 
Comparison       SVWN:   -76.0145245063 : 3.71e-12      nan 
Comparison      TPSSH:   -76.3809020339 :      nan 2.12e-06 
Comparison       WB97:   -76.3673725813 : 4.51e-10 6.18e-05 
Comparison      WB97X:   -76.3625416795 : 2.76e-03 4.24e-05 *
Comparison    WB97X-D:   -76.3616600437 : 1.75e-10 1.90e-05 
Comparison       WPBE:   -76.3341949063 : 4.52e-10      nan 
Comparison      WPBE0:   -76.3186294128 : 2.48e-10      nan 
Comparison      X3LYP:   -76.3549491651 :      nan 2.86e-05  ```

## Status
- [X]  Ready to go


