### PR TITLE
Changed printout to ValidationError

### DIFF
--- a/psi4/driver/procedures/response/scf_response.py
+++ b/psi4/driver/procedures/response/scf_response.py
@@ -145,7 +145,7 @@ def cpscf_linear_response(wfn, *args, **kwargs):
 
         # verify that this vector already has the correct shape
         elif shape != (ndocc, nvirt):
-            core.print_out('ERROR: "{}" has an unrecognized shape. Must be either ({}, {}) or ({}, {})\n'.format(
+            raise ValidationError('ERROR: "{}" has an unrecognized shape. Must be either ({}, {}) or ({}, {})'.format(
                 vector_names[i], nbf, nbf, ndocc, nvirt
             ))
 


### PR DESCRIPTION
## Description
Raise a ValidationError when CP SCF cannot handle user-passed vectors correctly.

## Todos
  - [x] Changed `core.print_out` to `raise ValidationError`

## Status
- [x]  Ready to go


