### PR TITLE
fix libxc with erd. try again on the Libxc::xc core link

### DIFF
--- a/psi4/driver/procedures/dft_funcs/superfuncs.py
+++ b/psi4/driver/procedures/dft_funcs/superfuncs.py
@@ -161,7 +161,7 @@ def build_superfunctional(alias, restricted):
         raise KeyError("SCF: Functional (%s) not found!" % alias)
 
 
-    if (core.get_global_option('INTEGRAL_PACKAGE') == 'ERD') and (sup.is_x_lrc() or sup.is_c_lrc()):
+    if (core.get_global_option('INTEGRAL_PACKAGE') == 'ERD') and (sup[0].is_x_lrc() or sup[0].is_c_lrc()):
         raise ValidationError("INTEGRAL_PACKAGE ERD does not play nicely with omega ERI's, so stopping.")
 
     # Set options

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -30,9 +30,9 @@ target_link_libraries(core PRIVATE ${PRE_LIBRARY_OPTION} dpd qt ${POST_LIBRARY_O
 if(TARGET dkh::dkh)
     target_compile_definitions(core PRIVATE $<TARGET_PROPERTY:dkh::dkh,INTERFACE_COMPILE_DEFINITIONS>)
 endif()
+target_include_directories(core PRIVATE $<TARGET_PROPERTY:Libxc::xc,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(core PRIVATE ${psi4_binmodules})
 target_link_libraries(core PRIVATE ${LIBC_INTERJECT})
-target_link_libraries(core PRIVATE Libxc::xc)
 target_link_libraries(core PUBLIC pybind11::module)
 target_link_libraries(core PRIVATE Threads::Threads)
 


### PR DESCRIPTION
## Description
erd and core link fixes

## Todos
Notable points that this PR has either accomplished or will accomplish.
* **Developer Interest**
  - [x] Libxc + ERD compatibility (high priority, I know) reconciled
  - [x] Trying another core linking scheme. If this gets accepted, let me know if you have problems again, @schiebermc 
* **User-Facing for Release Notes**

## Status
- [x]  Ready to go